### PR TITLE
Panic Causes Process Termination InvalidQuartiles Error Type Created

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl Display for TlshError {
                 write!(f, "TLSH requires an input of at least 50 bytes.")
             }
             TlshError::ParseHexFailed => write!(f, "Can't convert hex string to integer"),
-            TlshError::InvalidQuartiles => write!(f, "Failed to create proper quartiles"),
+            TlshError::InvalidQuartiles => write!(f, "Failed to create correct quartiles"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,7 @@ impl Display for TlshError {
                 write!(f, "TLSH requires an input of at least 50 bytes.")
             }
             TlshError::ParseHexFailed => write!(f, "Can't convert hex string to integer"),
+            TlshError:InvalidQuartiles => write!(f, "Failed to create proper quartiles"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl Display for TlshError {
                 write!(f, "TLSH requires an input of at least 50 bytes.")
             }
             TlshError::ParseHexFailed => write!(f, "Can't convert hex string to integer"),
-            TlshError:InvalidQuartiles => write!(f, "Failed to create proper quartiles"),
+            TlshError::InvalidQuartiles => write!(f, "Failed to create proper quartiles"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum TlshError {
     MinSizeNotReached,
     /// Fails to parse a hex string to integer.
     ParseHexFailed,
+    /// Failed to create correct quartiles.
+    InvalidQuartiles,
 }
 
 impl From<ParseIntError> for TlshError {

--- a/src/tlsh.rs
+++ b/src/tlsh.rs
@@ -208,7 +208,7 @@ impl TlshBuilder {
         let (q1, q2, q3) = find_quartiles(&self.buckets, self.bucket_count);
 
         if q3 == 0 {
-            panic!("q3 = 0")
+            Err(TlshError::InvalidQuartiles)?
         }
 
         let mut tmp = vec![0; self.code_size];


### PR DESCRIPTION
I've been encountering issues, with the inclusion of `panic` in this case.

It makes more sense to pass control to the user of the library the error so they can handle it.

I've added the error `InvalidQuartiles`, so the user can handle these errors as we are already passing the user a `Result`.